### PR TITLE
Added ThisPageCount

### DIFF
--- a/js/ko.pager.js
+++ b/js/ko.pager.js
@@ -41,7 +41,13 @@
         self.LastItemIndex = ko.computed(function () {
             return Math.min(self.FirstItemIndex() + self.PageSize() - 1, self.TotalItemCount());
         });
-
+        
+        self.ThisPageCount = ko.computed(function() {
+            var mod = self.LastItemIndex() % self.PageSize();
+            if (mod > 0) return mod;
+            return self.PageSize();
+        });
+        
         self.Pages = ko.computed(function () {
             var pageCount = self.LastPage();
             var pageFrom = Math.max(1, self.CurrentPage() - self.PageSlide());


### PR DESCRIPTION
I've found this to be useful when paging backwards through a grid. If a user navigates backwards from the first page they end up on the last page which may not have a full PageSize count. This provides the count for the number of items in the grid on the current page.
