### PR TITLE
ko.pager accepts a select function that will be called when the user click on a page number

### DIFF
--- a/example.html
+++ b/example.html
@@ -51,8 +51,8 @@
                     searchText = self.SearchText(),
                     startIndex = (self.Pager().CurrentPage() - 1) * maximumRows;
                 myService.search(searchText, startIndex, maximumRows)
-                    .done(function(result) { 
-                        // set your own results etc... 
+                    .done(function(result) {
+                        // set your own results etc...
                         self.TotalResults(result.totalItemCount);
                     }
                 */
@@ -155,11 +155,11 @@
             <!-- /ko -->
             <!-- ko ifnot:CurrentPage() === 1 -->
             <li>
-                <a href="#" data-bind="click: function(){ CurrentPage(1); }">&laquo;&laquo;</a></li>
+                <a href="#" data-bind="click: function(){ selectPage(1); }">&laquo;&laquo;</a></li>
             <!-- /ko -->
             <!-- ko if:HasPrevPage -->
             <li>
-                <a href="#" data-bind="click: function(){ CurrentPage(CurrentPage() - 1); }">&laquo;</a></li>
+                <a href="#" data-bind="click: function(){ selectPage(CurrentPage() - 1); }">&laquo;</a></li>
             <!-- /ko -->
             <!-- ko ifnot:HasPrevPage -->
             <li class="disabled">
@@ -173,13 +173,13 @@
             <!-- /ko -->
             <!-- ko if:$data !== $parent.CurrentPage() -->
             <li>
-                <a href="#" data-bind="text: $data, click: function(){ $parent.CurrentPage($data); }"></a>
+                <a href="#" data-bind="text: $data, click: function(){ $parent.selectPage($data); }"></a>
             </li>
             <!-- /ko -->
             <!-- /ko -->
             <!-- ko if:HasNextPage -->
             <li>
-                <a href="#" data-bind="click: function(){ CurrentPage(CurrentPage() + 1); }">&raquo;</a></li>
+                <a href="#" data-bind="click: function(){ selectPage(CurrentPage() + 1); }">&raquo;</a></li>
             <!-- /ko -->
             <!-- ko ifnot:HasNextPage -->
             <li class="disabled">
@@ -187,7 +187,7 @@
             <!-- /ko -->
             <!-- ko ifnot:CurrentPage() === LastPage() -->
             <li>
-                <a href="#" data-bind="click: function(){ CurrentPage(LastPage()); }">&raquo;&raquo;</a></li>
+                <a href="#" data-bind="click: function(){ selectPage(LastPage()); }">&raquo;&raquo;</a></li>
             <!-- /ko -->
             <!-- ko if:CurrentPage() === LastPage() -->
             <li class="disabled">

--- a/js/ko.pager.js
+++ b/js/ko.pager.js
@@ -15,13 +15,19 @@
         return result;
     };
 
-    function Pager(totalItemCount) {
+    function Pager(totalItemCount, selectPageFn, context) {
         var self = this;
         self.CurrentPage = numericObservable(1);
         self.TotalItemCount = ko.computed(totalItemCount);
         self.PageSize = numericObservable(10);
         self.PageSlide = numericObservable(2);
 
+        self.selectPage = function(page) {
+            self.CurrentPage(page);
+            context = context || this;
+            if(selectPageFn)
+                selectPageFn.bind(context)();
+        };
         self.LastPage = ko.computed(function () {
             return Math.floor((self.TotalItemCount() - 1) / self.PageSize()) + 1;
         });
@@ -41,13 +47,13 @@
         self.LastItemIndex = ko.computed(function () {
             return Math.min(self.FirstItemIndex() + self.PageSize() - 1, self.TotalItemCount());
         });
-        
+
         self.ThisPageCount = ko.computed(function() {
             var mod = self.LastItemIndex() % self.PageSize();
             if (mod > 0) return mod;
             return self.PageSize();
         });
-        
+
         self.Pages = ko.computed(function () {
             var pageCount = self.LastPage();
             var pageFrom = Math.max(1, self.CurrentPage() - self.PageSlide());
@@ -63,8 +69,8 @@
         });
     }
 
-    ko.pager = function (totalItemCount) {
-        var pager = new Pager(totalItemCount);
+    ko.pager = function (totalItemCount, selectPageFn, context) {
+        var pager = new Pager(totalItemCount, selectPageFn, context);
         return ko.observable(pager);
     };
 }(ko));


### PR DESCRIPTION
made ko.pager accept two extra parameters (selecFn & its context) (they are both optional)

Why observing current page wasn't suitable?

I was developing a complicated grid, so what i wanted is when the user clicks on a page number will call fetch result, but i also wanted when the user changes the filter to do many things including change the page number to be the 1st page and in the end will call fetch result, so i didn't want in that case to fire the observe method that i had setup
